### PR TITLE
Fixed implicit any warn and improved speed of startall scripts

### DIFF
--- a/ReStyle-Backend/package.json
+++ b/ReStyle-Backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "tsc && ts-node ./src/server.ts",
-    "startall": "cd ../ReStyle-Frontend && ng build --prod && cd ../ReStyle-Backend && tsc && ts-node ./src/server.ts"
+    "startall": "cd ../ReStyle-Frontend && ng build && cd ../ReStyle-Backend && tsc && ts-node ./src/server.ts"
   },
   "keywords": [],
   "author": "",

--- a/ReStyle-Backend/src/server.ts
+++ b/ReStyle-Backend/src/server.ts
@@ -5,7 +5,7 @@ const app = express();
 app.use('/', express.static('../ReStyle-Frontend/dist/ReStyle'));
 
 // this is an example used to test sending simple data to the front end
-app.get('/ajax', function (req, res) {
+app.get('/ajax', function (req: any, res: any) {
     res.send({'text': 'hello angular'});
 });
 

--- a/ReStyle-Frontend/package.json
+++ b/ReStyle-Frontend/package.json
@@ -8,7 +8,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "startall": "ng build --prod && cd ../ReStyle-Backend && tsc && ts-node ./src/server.ts"
+    "startall": "ng build && cd ../ReStyle-Backend && tsc && ts-node ./src/server.ts"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Fixed the ts warning that `req` and `res` had implicit types of `any`

Removed --prod from both startall scripts to improve performance - attacked screenshot shows the speed difference between `ng build --prod` and `ng build`

![image](https://user-images.githubusercontent.com/47646286/57199705-d5f48600-6f36-11e9-99ec-3ef0f86157c6.png)

